### PR TITLE
Added arm-gcc-10-2020-q4 revision

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,5 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ./
       with: 
-        release: 9-2020-q2
+        release: 10-2020-q4
     - run: arm-none-eabi-gcc -v

--- a/dist/index.js
+++ b/dist/index.js
@@ -24950,6 +24950,7 @@ function Extract (opts) {
 
 Object.defineProperty(exports, "__esModule", { value: true });
 const versions = {
+    '10-2020-q4':'https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-${ARCH_OS}.${EXT}',
     '9-2020-q2': 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-${ARCH_OS}.${EXT}',
     '9-2019-q4': 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-${ARCH_OS}.${EXT}',
     '8-2019-q3': 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-${OS}.${EXT}',

--- a/src/gcc.ts
+++ b/src/gcc.ts
@@ -1,4 +1,6 @@
 const versions: {[key: string]: string} = {
+  '10-2020-q4':
+    'https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-${ARCH_OS}.${EXT}',
   '9-2020-q2':
     'https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-${ARCH_OS}.${EXT}',
   '9-2019-q4':


### PR DESCRIPTION
The new stable version of gnu-arm toolchain is available. Because of some C++ features and bugfixes that are supplied with 10.2 gcc version it would be fine to update the existing GitHub action for adding the support of the new compiler.

